### PR TITLE
Add support for gradient stop points

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
         <script src="//pixijs.download/release/pixi.js"></script>
         <script src="//cdnjs.cloudflare.com/ajax/libs/mithril/1.1.1/mithril.js"></script>
         <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+        <script src="js/utils/deepCopy.js?v=1"></script>
+        <script src="js/utils/deepEqual.js?v=1"></script>
         <script src="js/components/StyleComponent.js?v=1"></script>
         <script src="js/components/StyleCheckbox.js?v=1"></script>
         <script src="js/components/StyleNumber.js?v=1"></script>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <script src="js/components/StyleSelect.js?v=1"></script>
         <script src="js/components/StyleColor.js?v=1"></script>
         <script src="js/components/StyleColorGradient.js?v=1"></script>
+        <script src="js/components/StyleStopPoints.js?v=1"></script>
         <script src="js/components/StyleBackgroundColor.js?v=1"></script>
         <script src="js/mixins/TextStyle.js?v=1"></script>
         <script src="js/TextStyleEditor.js?v=1"></script>

--- a/js/TextStyleEditor.js
+++ b/js/TextStyleEditor.js
@@ -5,14 +5,14 @@
  * @class TextStyleEditor
  */
 class TextStyleEditor {
-        
+
     constructor() {
         this.defaults = new PIXI.TextStyle();
 
         this.defaultText = 'Hello World';
         this.defaultBG = '#ffffff';
         this.style = new PIXI.TextStyle();
-        
+
         // The default dropShadowColor is "#000000",
         // this makes it consistent with fill, strokeFill, etc
         this.defaults.dropShadowColor = 'black';
@@ -25,7 +25,7 @@ class TextStyleEditor {
         let values = {
             text: localStorage.text || this.defaultText,
             background: localStorage.background || this.defaultBG,
-            style: JSON.parse(localStorage.style || null) || this.defaults.toJSON()
+            style: JSON.parse(localStorage.style || null) || this.style.toJSON()
         };
 
         // Revert from the window hash
@@ -88,7 +88,7 @@ class TextStyleEditor {
                             })
                         ])
                     ]),
-                    
+
                     m('h4', 'Font'),
                     this.select('fontFamily', 'Font Family', [
                         'Arial',
@@ -147,6 +147,7 @@ class TextStyleEditor {
                         [0, 'linear vertical'],
                         [1, 'linear horizontal']
                     ]),
+                    this.stopPoints('fillGradientStops', 'Fill Gradient Stops', 0.1, 0, 1),
 
                     m('h4', 'Stroke'),
                     this.color('stroke', 'Color'),
@@ -175,7 +176,7 @@ class TextStyleEditor {
                     this.number('dropShadowAngle', 'Angle', 0.1),
                     this.number('dropShadowBlur', 'Blur'),
                     this.number('dropShadowDistance', 'Distance'),
-                    
+
                     m('h4', 'Multiline'),
                     this.checkbox('wordWrap', 'Enable'),
                     this.checkbox('breakWords', 'Break Words'),
@@ -185,7 +186,7 @@ class TextStyleEditor {
                         'right'
                     ]),
                     this.number('wordWrapWidth', 'Wrap Width', 10, 0),
-                    this.number('lineHeight', 'Line Height', 1, 0),                
+                    this.number('lineHeight', 'Line Height', 1, 0),
 
                     m('h4', 'Texture'),
                     this.number('padding', 'Padding'),
@@ -257,6 +258,10 @@ class TextStyleEditor {
 
     number(id, name, step, min, max) {
         return m(StyleNumber, { parent: this, id, name, step, min, max });
+    }
+
+    stopPoints(id, name, step, min, max) {
+        return m(StyleStopPoints, { parent: this, id, name, step, min, max });
     }
 
     checkbox(id, name) {
@@ -341,7 +346,7 @@ class TextStyleEditor {
             hash.background = this.background;
         }
 
-        const encoded = Object.keys(hash).length ? 
+        const encoded = Object.keys(hash).length ?
             encodeURIComponent(JSON.stringify(hash)) : '';
 
         history.replaceState(null, null, `#${encoded}`);

--- a/js/TextStyleEditor.js
+++ b/js/TextStyleEditor.js
@@ -18,6 +18,11 @@ class TextStyleEditor {
         this.defaults.dropShadowColor = 'black';
         this.style.dropShadowColor = 'black';
 
+        // Temporary fix since the array is copied by reference in PIXI.TextStyle
+        // To be removed when that is fixed within PIXI itself
+        this.style.fillGradientStops = [0];
+        this.style.fillGradientStops = [];
+
         this.text = new PIXI.Text('', this.style);
         this.text.anchor.set(0.5);
 

--- a/js/TextStyleEditor.js
+++ b/js/TextStyleEditor.js
@@ -410,7 +410,7 @@ class TextStyleEditor {
 
             if (pretty) {
                 data = this.prettify(data);
-        }
+            }
         }
 
         const text = this.text.text.replace(/\n/g, '\\n')

--- a/js/TextStyleEditor.js
+++ b/js/TextStyleEditor.js
@@ -18,11 +18,6 @@ class TextStyleEditor {
         this.defaults.dropShadowColor = 'black';
         this.style.dropShadowColor = 'black';
 
-        // Temporary fix since the array is copied by reference in PIXI.TextStyle
-        // To be removed when that is fixed within PIXI itself
-        this.style.fillGradientStops = [0];
-        this.style.fillGradientStops = [];
-
         this.text = new PIXI.Text('', this.style);
         this.text.anchor.set(0.5);
 

--- a/js/TextStyleEditor.js
+++ b/js/TextStyleEditor.js
@@ -50,7 +50,7 @@ class TextStyleEditor {
         });
         this.app.renderer.plugins.interaction.autoPreventDefault = false;
 
-        this.copyPropertiesByValue(values.style, this.style);
+        deepCopy(this.style, values.style);
 
         this.text.text = values.text;
         this.background = values.background;
@@ -283,8 +283,7 @@ class TextStyleEditor {
         localStorage.removeItem('background');
         localStorage.removeItem('style');
         localStorage.removeItem('text');
-        const style = this.defaults.toJSON();
-        this.copyPropertiesByValue(style, this.style);
+        deepCopy(this.style, this.defaults.toJSON());
 
         this.text.text = this.defaultText;
         this.background = this.defaultBG;
@@ -319,7 +318,7 @@ class TextStyleEditor {
     getCode(jsonOnly) {
         const style = this.style.toJSON();
         for (const name in style) {
-            if (this.deepEqual(style[name], this.defaults[name])) {
+            if (deepEqual(style[name], this.defaults[name])) {
                 delete style[name];
             }
         }
@@ -349,7 +348,7 @@ class TextStyleEditor {
 
         history.replaceState(null, null, `#${encoded}`);
 
-        if (data === '{}' || data === '[]') {
+        if (data === '{}') {
             data = '';
         } else {
             data = data.replace(/\"([^\"]+)\"\:/g, '$1:')
@@ -377,43 +376,5 @@ class TextStyleEditor {
 
         // Listen for resize events
         window.addEventListener('resize', this.resize.bind(this), false);
-    }
-
-    copyPropertiesByValue(source, target) {
-        for (const prop in source) {
-            if (Array.isArray(source[prop])) {
-                target[prop] = source[prop].slice();
-            } else if (source[prop] && typeof source[prop] === 'object') {
-                Object.assign(target[prop], source[prop]);
-            } else {
-                target[prop] = source[prop];
-            }
-        }
-    }
-
-    deepEqual(a, b) {
-        if (a === b) {
-            return true;
-        }
-
-        if (typeof a !== typeof b || a == null || typeof a != "object" || b == null || typeof b != "object") {
-            return false;
-        }
-
-        let propsInA = 0;
-        let propsInB = 0;
-
-        for (const prop in a) {
-            ++propsInA;
-        }
-
-        for (const prop in b) {
-            ++propsInB;
-            if (!(prop in a) || !this.deepEqual(a[prop], b[prop])) {
-                return false;
-            }
-        }
-
-        return propsInA == propsInB;
     }
 }

--- a/js/components/StyleStopPoints.js
+++ b/js/components/StyleStopPoints.js
@@ -17,8 +17,7 @@ class StyleStopPoints extends StyleComponent {
         let contents;
         if (!Array.isArray(values)) {
             contents = [];
-        }
-        else {
+        } else {
             contents = values.map((value, i) => {
 
                 let buttons = [

--- a/js/components/StyleStopPoints.js
+++ b/js/components/StyleStopPoints.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * Input selector for stop points, for example, on a color gradient
+ * @class StyleStopPoints
+ * @extends StyleComponent
+ */
+class StyleStopPoints extends StyleComponent {
+    constructor(vnode) {
+        super(vnode);
+        this.step = vnode.attrs.step || 1;
+        this.min = vnode.attrs.min;
+        this.max = vnode.attrs.max;
+    }
+    init() {
+        const values = this.parent.style[this.id];
+        let contents;
+        if (!Array.isArray(values)) {
+            contents = [];
+        }
+        else {
+            contents = values.map((value, i) => {
+
+                let buttons = [
+                    m('button.btn.btn-sm.btn-default', {
+                        key: this.id + 'Remove' + i,
+                        onclick: this.removeStop.bind(this, i)
+                    }, m('span.glyphicon.glyphicon-remove'))
+                ];
+
+                return m('div.input-group.color-group', [
+                    m('input.form-control.input-sm.number[type=number]#' + this.id + i, {
+                        key: this.id + i,
+                        oninput: m.withAttr('value', this.updateIndex.bind(this, i)),
+                        step: this.step,
+                        min: this.min,
+                        max: this.max,
+                        value
+                    }),
+                    m('span.input-group-btn', buttons)
+                ]);
+            });
+        }
+        return m('div', contents.concat([
+            m('button.btn-block.btn.btn-sm.btn-default', {
+                key: this.id + 'Add',
+                onclick: this.addStop.bind(this)
+            }, [
+                    m('span.glyphicon.glyphicon-plus'), ' Add Stop Point'
+                ]
+            )
+        ]));
+    }
+
+    removeStop(index) {
+        let values = this.parent.style[this.id];
+        values.splice(index, 1);
+        this.update(values.slice());
+    }
+
+    updateIndex(index, value) {
+        this.parent.style[this.id][index] = value;
+        this.update(this.parent.style[this.id].slice());
+    }
+
+    addStop() {
+        let values = this.parent.style[this.id];
+
+        if (!Array.isArray(values)) {
+            values = [values];
+        }
+        values.push(values[values.length - 1] || 0);
+        this.update(values);
+        m.redraw();
+    }
+}

--- a/js/components/StyleStopPoints.js
+++ b/js/components/StyleStopPoints.js
@@ -40,7 +40,7 @@ class StyleStopPoints extends StyleComponent {
                 ]);
             });
         }
-        return m('div', contents.concat([
+        return m('div.gradient', contents.concat([
             m('button.btn-block.btn.btn-sm.btn-default', {
                 key: this.id + 'Add',
                 onclick: this.addStop.bind(this)

--- a/js/mixins/TextStyle.js
+++ b/js/mixins/TextStyle.js
@@ -10,7 +10,14 @@ PIXI.TextStyle.prototype.toJSON = function() {
     for(const n in this) {
         if (n.indexOf('_') === 0) {
             const field = n.slice(1);
-            result[field] = this[field];
+
+            if (Array.isArray(this[field])) {
+                result[field] = this[field].slice();
+            } else if (this[field] && typeof this[field] === 'object') {
+                Object.assign(result[field], this[field]);
+            } else {
+                result[field] = this[field];
+            }
         }
     }
     return result;

--- a/js/mixins/TextStyle.js
+++ b/js/mixins/TextStyle.js
@@ -10,14 +10,7 @@ PIXI.TextStyle.prototype.toJSON = function() {
     for(const n in this) {
         if (n.indexOf('_') === 0) {
             const field = n.slice(1);
-
-            if (Array.isArray(this[field])) {
-                result[field] = this[field].slice();
-            } else if (this[field] && typeof this[field] === 'object') {
-                Object.assign(result[field], this[field]);
-            } else {
-                result[field] = this[field];
-            }
+            result[field] = this[field];
         }
     }
     return result;

--- a/js/utils/deepCopy.js
+++ b/js/utils/deepCopy.js
@@ -4,8 +4,6 @@ function deepCopy(target, source) {
     for (const prop in source) {
         if (Array.isArray(source[prop])) {
             target[prop] = source[prop].slice();
-        } else if (source[prop] && typeof source[prop] === 'object') {
-            Object.assign(target[prop], source[prop]);
         } else {
             target[prop] = source[prop];
         }

--- a/js/utils/deepCopy.js
+++ b/js/utils/deepCopy.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function deepCopy(target, source) {
+    for (const prop in source) {
+        if (Array.isArray(source[prop])) {
+            target[prop] = source[prop].slice();
+        } else if (source[prop] && typeof source[prop] === 'object') {
+            Object.assign(target[prop], source[prop]);
+        } else {
+            target[prop] = source[prop];
+        }
+    }
+}

--- a/js/utils/deepEqual.js
+++ b/js/utils/deepEqual.js
@@ -1,0 +1,27 @@
+'use strict';
+
+function deepEqual(a, b) {
+    if (a === b) {
+        return true;
+    }
+
+    if (typeof a !== typeof b || a == null || typeof a != "object" || b == null || typeof b != "object") {
+        return false;
+    }
+
+    let propsInA = 0;
+    let propsInB = 0;
+
+    for (const prop in a) {
+        ++propsInA;
+    }
+
+    for (const prop in b) {
+        ++propsInB;
+        if (!(prop in a) || !deepEqual(a[prop], b[prop])) {
+            return false;
+        }
+    }
+
+    return propsInA == propsInB;
+}

--- a/js/utils/deepEqual.js
+++ b/js/utils/deepEqual.js
@@ -5,7 +5,7 @@ function deepEqual(a, b) {
         return true;
     }
 
-    if (typeof a !== typeof b || a == null || typeof a != "object" || b == null || typeof b != "object") {
+    if (typeof a !== typeof b || a == null || b === null || typeof a !== "object" || typeof b !== "object") {
         return false;
     }
 
@@ -23,5 +23,5 @@ function deepEqual(a, b) {
         }
     }
 
-    return propsInA == propsInB;
+    return propsInA === propsInB;
 }


### PR DESCRIPTION
As this requires dealing with arrays and not plain objects, some deep cloning and deep comparison of objects are required for equality; added as util files

There is a bug in pixi style where Text Style settings object is being cloned via Object.assign ... which doesn't deep clone the array. Therefore there is a temp fix to force making the this.style array unique via changing it's value directly