### PR TITLE
Fixes custom fonts not being visible when the page is refreshed

### DIFF
--- a/src/TextStyleEditor.jsx
+++ b/src/TextStyleEditor.jsx
@@ -120,7 +120,7 @@ export default class TextStyleEditor {
                             '"Courier New", Courier, monospace',
                             '"Lucida Console", Monaco, monospace'
                         ]} />
-                        <FontsLoader onrender={() => this.app.render()} style={this.style} />
+                        <FontsLoader onrender={() => this.app.render()} text={this.text} />
                         <StyleNumber parent={this} id='fontSize' name='Font Size' step='1' min='1' />
                         <StyleSelect parent={this} id='fontStyle' name='Font Style' options={[
                             'normal',


### PR DESCRIPTION
An updatedText() call now forces the canvas to be redrawn, solving the issue.
Also stopped the fontFamily from always being switched on a page load; if multiple custom fonts were loaded, it was always switching to the latest one
https://github.com/pixijs/pixi-text-style/issues/21